### PR TITLE
1.3.0 - Update for multiple predefined classes and option to use both text input and predefined classes

### DIFF
--- a/includes/widget-css-classes-library.class.php
+++ b/includes/widget-css-classes-library.class.php
@@ -81,12 +81,12 @@ class WCSSC_Lib {
 		if ( $version == 0 ) {
 			// add default options
 			$options = array(
-				'show_id'       	=> 0,
-				'type'          	=> 1,
+				'show_id'		=> 0,
+				'type'			=> 1,
 				'defined_classes'	=> '',
-				'show_number'   	=> 1,
-				'show_location' 	=> 1,
-				'show_evenodd'  	=> 1,
+				'show_number'		=> 1,
+				'show_location'		=> 1,
+				'show_evenodd'		=> 1,
 			);
 
 			add_option( 'WCSSC_options', $options );

--- a/includes/widget-css-classes-library.class.php
+++ b/includes/widget-css-classes-library.class.php
@@ -103,7 +103,11 @@ class WCSSC_Lib {
 			}
 			if ( $version < 1.3 ) {
 				$general_options         = get_option( 'WCSSC_options' );
+				if ( ! isset( $general_options['dropdown'] ) ) {
+					$general_options['dropdown'] = '';
+				}
 				$general_options['defined_classes'] = $general_options['dropdown'];
+				unset( $general_options['dropdown'] );
 				update_option( 'WCSSC_options', $general_options );
 			}
 		}

--- a/includes/widget-css-classes-library.class.php
+++ b/includes/widget-css-classes-library.class.php
@@ -103,6 +103,11 @@ class WCSSC_Lib {
 			}
 			if ( $version < 1.3 ) {
 				$general_options         = get_option( 'WCSSC_options' );
+				// Hide option is now 0 instead of 3
+				if ( isset( $general_options['type'] ) && $general_options['type'] == 3 ) {
+					$general_options['type'] = 0;
+				}
+				// dropdown settings are renamed to defined_classes
 				if ( ! isset( $general_options['dropdown'] ) ) {
 					$general_options['dropdown'] = '';
 				}

--- a/includes/widget-css-classes-library.class.php
+++ b/includes/widget-css-classes-library.class.php
@@ -81,12 +81,12 @@ class WCSSC_Lib {
 		if ( $version == 0 ) {
 			// add default options
 			$options = array(
-				'show_id'       => 0,
-				'type'          => 1,
-				'dropdown'      => '',
-				'show_number'   => 1,
-				'show_location' => 1,
-				'show_evenodd'  => 1,
+				'show_id'       	=> 0,
+				'type'          	=> 1,
+				'defined_classes'	=> '',
+				'show_number'   	=> 1,
+				'show_location' 	=> 1,
+				'show_evenodd'  	=> 1,
 			);
 
 			add_option( 'WCSSC_options', $options );
@@ -99,6 +99,11 @@ class WCSSC_Lib {
 				$general_options['show_number'] = 1;
 				$general_options['show_location'] = 1;
 				$general_options['show_evenodd'] = 1;
+				update_option( 'WCSSC_options', $general_options );
+			}
+			if ( $version < 1.3 ) {
+				$general_options         = get_option( 'WCSSC_options' );
+				$general_options['defined_classes'] = $general_options['dropdown'];
 				update_option( 'WCSSC_options', $general_options );
 			}
 		}

--- a/includes/widget-css-classes-settings.class.php
+++ b/includes/widget-css-classes-settings.class.php
@@ -158,6 +158,10 @@ class WCSSC_Settings {
 					foreach ( $import as $import_option ) {
 						list( $key, $value ) = explode( "\t", $import_option );
 						$options[$key] = json_decode( sanitize_text_field( $value ) );
+						if ( $options['dropdown'] ) { // Update for 1.3.0
+							$options['defined_classes'] = $options['dropdown'];
+							unset( $options['dropdown'] );
+						}
 					}
 					update_option( 'WCSSC_options', $options );
 					$wcssc_message = 1;

--- a/includes/widget-css-classes-settings.class.php
+++ b/includes/widget-css-classes-settings.class.php
@@ -45,7 +45,7 @@ class WCSSC_Settings {
 		add_settings_field( 'show_evenodd', esc_attr__( 'Add Even/Odd Classes', 'widget-css-classes' ), array( $this, 'show_evenodd_option' ), $this->general_key, 'section_general' );
 		add_settings_field( 'show_id', esc_attr__( 'Show Additional Field for ID', 'widget-css-classes' ), array( $this, 'show_id_option' ), $this->general_key, 'section_general' );
 		add_settings_field( 'type', esc_attr__( 'Class Field Type', 'widget-css-classes' ), array( $this, 'type_option' ), $this->general_key, 'section_general' );
-		add_settings_field( 'dropdown', esc_attr__( 'Define Classes for Dropdown', 'widget-css-classes' ), array( $this, 'dropdown_option' ), $this->general_key, 'section_general' );
+		add_settings_field( 'defined_classes', esc_attr__( 'Predefine Classes', 'widget-css-classes' ), array( $this, 'defined_classes_option' ), $this->general_key, 'section_general' );
 		do_action( 'widget_css_classes_settings' );
 	}
 
@@ -79,33 +79,34 @@ class WCSSC_Settings {
 	function type_option() {
 		?>
 		<input type="radio" name="<?php echo esc_attr( $this->general_key ).'[type]'; ?>" value="1" <?php checked( $this->general_settings['type'], 1 ); ?> /> <?php esc_attr_e( 'Text', 'widget-css-classes' ); ?>&nbsp;&nbsp;
-		<input type="radio" name="<?php echo esc_attr( $this->general_key ).'[type]'; ?>" value="2" <?php checked( $this->general_settings['type'], 2 ); ?> /> <?php esc_attr_e( 'Dropdown', 'widget-css-classes' ); ?>&nbsp;&nbsp;
-        <input type="radio" name="<?php echo esc_attr( $this->general_key ).'[type]'; ?>" value="3" <?php checked( $this->general_settings['type'], 3 ); ?> /> <?php esc_attr_e( 'Hide', 'widget-css-classes' ); ?>
+		<input type="radio" name="<?php echo esc_attr( $this->general_key ).'[type]'; ?>" value="2" <?php checked( $this->general_settings['type'], 2 ); ?> /> <?php esc_attr_e( 'Predefined', 'widget-css-classes' ); ?>&nbsp;&nbsp;
+		<input type="radio" name="<?php echo esc_attr( $this->general_key ).'[type]'; ?>" value="3" <?php checked( $this->general_settings['type'], 3 ); ?> /> <?php esc_attr_e( 'Both', 'widget-css-classes' ); ?>&nbsp;&nbsp;
+        <input type="radio" name="<?php echo esc_attr( $this->general_key ).'[type]'; ?>" value="0" <?php checked( $this->general_settings['type'], 0 ); ?> /> <?php esc_attr_e( 'Hide', 'widget-css-classes' ); ?>
 	<?php
 	}
 
-	function dropdown_option() {
-		$presets = explode( ';', $this->general_settings['dropdown'] );
+	function defined_classes_option() {
+		$presets = explode( ';', $this->general_settings['defined_classes'] );
 		if ( count( $presets ) > 1 ) {
 			foreach ( $presets as $key => $preset ) {
 				if ( $preset != '' ) {
 				?>
-					<p><input type="text" name="<?php echo esc_attr( $this->general_key ).'[dropdown]['.esc_attr( $key ).']'; ?>" value="<?php echo esc_attr( $preset ); ?>" />
+					<p><input type="text" name="<?php echo esc_attr( $this->general_key ).'[defined_classes]['.esc_attr( $key ).']'; ?>" value="<?php echo esc_attr( $preset ); ?>" />
 					<a class="wcssc_remove" href="#"><span class="dashicons dashicons-dismiss"></span></a></p>
 				<?php
 				}
 			}
 			?>
-			<p class="wcssc_dropdown">
-				<input type="text" name="<?php echo esc_attr( $this->general_key ).'[dropdown][]'; ?>" value="" />
-				<a href="#" class="wcssc_copy" rel=".wcssc_dropdown"><span class="dashicons dashicons-plus-alt"></span></a>
+			<p class="wcssc_defined_classes">
+				<input type="text" name="<?php echo esc_attr( $this->general_key ).'[defined_classes][]'; ?>" value="" />
+				<a href="#" class="wcssc_copy" rel=".wcssc_defined_classes"><span class="dashicons dashicons-plus-alt"></span></a>
 				<a class="wcssc_remove" href="#"><span class="dashicons dashicons-dismiss"></span></a>
 			</p>
 		<?php
 		} else {
 			?>
-			<p class="wcssc_dropdown"><input type="text" name="<?php echo esc_attr( $this->general_key ).'[dropdown][]'; ?>" value="<?php echo esc_attr( $this->general_settings['dropdown'] ); ?>" />
-			<a href="#" class="wcssc_copy" rel=".wcssc_dropdown"><span class="dashicons dashicons-plus-alt"></span></a>
+			<p class="wcssc_defined_classes"><input type="text" name="<?php echo esc_attr( $this->general_key ).'[defined_classes][]'; ?>" value="<?php echo esc_attr( $this->general_settings['defined_classes'] ); ?>" />
+			<a href="#" class="wcssc_copy" rel=".wcssc_defined_classes"><span class="dashicons dashicons-plus-alt"></span></a>
 			<a class="wcssc_remove" href="#"><span class="dashicons dashicons-dismiss"></span></a></p>
 		<?php
 		}
@@ -178,7 +179,7 @@ class WCSSC_Settings {
 		foreach ( $input as $key => $value ) {
 
 			if ( isset( $input[$key] ) ) {
-				if ( $key == 'dropdown' ) {
+				if ( $key == 'defined_classes' ) {
 					if ( is_array( $value ) ) {
 						$output[$key] = implode( ';', $input[$key] );
 					} else {

--- a/includes/widget-css-classes-settings.class.php
+++ b/includes/widget-css-classes-settings.class.php
@@ -45,7 +45,7 @@ class WCSSC_Settings {
 		add_settings_field( 'show_evenodd', esc_attr__( 'Add Even/Odd Classes', 'widget-css-classes' ), array( $this, 'show_evenodd_option' ), $this->general_key, 'section_general' );
 		add_settings_field( 'show_id', esc_attr__( 'Show Additional Field for ID', 'widget-css-classes' ), array( $this, 'show_id_option' ), $this->general_key, 'section_general' );
 		add_settings_field( 'type', esc_attr__( 'Class Field Type', 'widget-css-classes' ), array( $this, 'type_option' ), $this->general_key, 'section_general' );
-		add_settings_field( 'defined_classes', esc_attr__( 'Predefine Classes', 'widget-css-classes' ), array( $this, 'defined_classes_option' ), $this->general_key, 'section_general' );
+		add_settings_field( 'defined_classes', esc_attr__( 'Predefined Classes', 'widget-css-classes' ), array( $this, 'defined_classes_option' ), $this->general_key, 'section_general' );
 		do_action( 'widget_css_classes_settings' );
 	}
 

--- a/includes/widget-css-classes.class.php
+++ b/includes/widget-css-classes.class.php
@@ -75,7 +75,8 @@ class WCSSC {
 						if ( in_array( $preset, $instance['classes-defined'] ) ) {
 							$preset_checked = 'checked="checked"';
 						}
-						$fields .= "\t<li><input name='widget-{$widget->id_base}[{$widget->number}][classes-defined][]' type='checkbox' value='".$preset."' ".$preset_checked."> ".$preset."</li>\n";
+						$id = 'widget-'.$widget->id_base.'-'.$widget->number.'-classes-defined-'.$preset;
+						$fields .= "\t<li><input id='{$id}' name='widget-{$widget->id_base}[{$widget->number}][classes-defined][]' type='checkbox' value='".$preset."' ".$preset_checked."> <label for='{$id}'>".$preset."</label></li>\n";
 					}
 				}
 				$fields .= "\t</ul>\n";

--- a/includes/widget-css-classes.class.php
+++ b/includes/widget-css-classes.class.php
@@ -27,7 +27,6 @@ class WCSSC {
 		if ( !isset( $instance['classes'] ) ) $instance['classes'] = null;
 		if ( !isset( $instance['classes-defined'] ) ) $instance['classes-defined'] = array();
 		
-				
 		$fields = '';
 		
 		if ( WCSSC_Loader::$settings['show_id'] == 1 || WCSSC_Loader::$settings['type'] > 0 ) {
@@ -42,6 +41,16 @@ class WCSSC {
 	
 			// show text field
 			if ( WCSSC_Loader::$settings['type'] == 1 ) {
+				
+				// Merge predefined classes with input classes
+				$text_classes = explode( ' ', $instance['classes'] );
+				foreach ( $instance['classes-defined'] as $key => $value ) {
+					if ( ! in_array( $value, $text_classes ) ) {
+						$text_classes[] = $value;
+					}
+				}
+				$instance['classes'] = implode( ' ', $text_classes );
+				
 				$fields .= "\t<label for='widget-{$widget->id_base}-{$widget->number}-classes'>".apply_filters( 'widget_css_classes_class', esc_html__( 'CSS Classes', 'widget-css-classes' ) ).":</label>
 				<input type='text' name='widget-{$widget->id_base}[{$widget->number}][classes]' id='widget-{$widget->id_base}-{$widget->number}-classes' value='{$instance['classes']}' class='widefat' />\n";
 			}
@@ -105,6 +114,16 @@ class WCSSC {
 			$instance['ids']     = $new_instance['ids'];
 		}
 		
+		if ( WCSSC_Loader::$settings['type'] == 1 ) {
+			// Merge predefined classes with input classes
+			$text_classes = explode( ' ', $instance['classes'] );
+			foreach ( $instance['classes-defined'] as $key => $value ) {
+				if ( ! in_array( $value, $text_classes ) ) {
+					$text_classes[] = $value;
+				}
+			}
+			$instance['classes'] = implode( ' ', $text_classes );
+		}
 		if ( WCSSC_Loader::$settings['type'] == 2 || WCSSC_Loader::$settings['type'] == 3 ) {
 			// Merge input classes with predefined classes
 			$preset_values = explode( ';', WCSSC_Loader::$settings['defined_classes'] );
@@ -179,14 +198,29 @@ class WCSSC {
 			}
 		}
 
+		$presets = explode( ';', $widget_css_classes['defined_classes'] );
+		
 		// add classes
 		if ( $widget_css_classes['type'] == 1 || $widget_css_classes['type'] == 3 ) {
-			if ( isset( $widget_opt[$widget_num]['classes'] ) && !empty( $widget_opt[$widget_num]['classes'] ) )
+			if ( isset( $widget_opt[$widget_num]['classes'] ) && !empty( $widget_opt[$widget_num]['classes'] ) ) {
 				$params[0]['before_widget'] = preg_replace( '/class="/', "class=\"{$widget_opt[$widget_num]['classes']} ", $params[0]['before_widget'], 1 );
+			}
+			// If there are predefined classes selected in the widget before the setting was changed, check if they exist. If so, add them to the displayed classes
+			if ( 	$widget_css_classes['type'] == 1 
+				 && isset( $widget_opt[$widget_num]['classes-defined'] ) 
+				 && !empty( $widget_opt[$widget_num]['classes-defined'] ) 
+				 && is_array( $widget_opt[$widget_num]['classes-defined'] ) 
+			) {
+				foreach ( $widget_opt[$widget_num]['classes-defined'] as $key => $value ) {
+					if ( in_array( $value, $presets ) ) {
+						$value = esc_attr( $value );
+						$params[0]['before_widget'] = preg_replace( '/class="/', "class=\"{$value} ", $params[0]['before_widget'], 1 );
+					}
+				}
+			}
 		}
 		
 		// add selected predefined classes
-		$presets = explode( ';', $widget_css_classes['defined_classes'] );
 		if ( $widget_css_classes['type'] == 2 || $widget_css_classes['type'] == 3 ) {
 			if ( isset( $widget_opt[$widget_num]['classes-defined'] ) && !empty( $widget_opt[$widget_num]['classes-defined'] ) && is_array( $widget_opt[$widget_num]['classes-defined'] ) ) {
 				foreach ( $widget_opt[$widget_num]['classes-defined'] as $key => $value ) {

--- a/includes/widget-css-classes.class.php
+++ b/includes/widget-css-classes.class.php
@@ -195,6 +195,15 @@ class WCSSC {
 						$params[0]['before_widget'] = preg_replace( '/class="/', "class=\"{$value} ", $params[0]['before_widget'], 1 );
 					}
 				}
+			} else if ( $widget_css_classes['type'] == 2 && isset( $widget_opt[$widget_num]['classes'] ) && !empty( $widget_opt[$widget_num]['classes'] ) ) {
+				// Add predefined classes if they are set as normal classes. Also takes case of compatibility for versions lower than 1.3
+				$classes = explode( ' ', $widget_opt[$widget_num]['classes'] );
+				foreach ( $classes as $key => $value ) {
+					if ( in_array( $value, $presets ) ) {
+						$value = esc_attr( $value );
+						$params[0]['before_widget'] = preg_replace( '/class="/', "class=\"{$value} ", $params[0]['before_widget'], 1 );
+					}
+				}
 			}
 		}
 		

--- a/includes/widget-css-classes.class.php
+++ b/includes/widget-css-classes.class.php
@@ -185,6 +185,7 @@ class WCSSC {
 				$params[0]['before_widget'] = preg_replace( '/class="/', "class=\"{$widget_opt[$widget_num]['classes']} ", $params[0]['before_widget'], 1 );
 		}
 		
+		// add selected predefined classes
 		$presets = explode( ';', $widget_css_classes['defined_classes'] );
 		if ( $widget_css_classes['type'] == 2 || $widget_css_classes['type'] == 3 ) {
 			if ( isset( $widget_opt[$widget_num]['classes-defined'] ) && !empty( $widget_opt[$widget_num]['classes-defined'] ) && is_array( $widget_opt[$widget_num]['classes-defined'] ) ) {

--- a/includes/widget-css-classes.class.php
+++ b/includes/widget-css-classes.class.php
@@ -25,38 +25,48 @@ class WCSSC {
 	 */
 	public static function extend_widget_form( $widget, $return, $instance ) {
 		if ( !isset( $instance['classes'] ) ) $instance['classes'] = null;
+		if ( !isset( $instance['classes-defined'] ) ) $instance['classes-defined'] = array();
+		
 		$fields = '';
-
-		// show id field
-		if ( WCSSC_Loader::$settings['show_id'] == 1 ) {
-			if ( !isset( $instance['ids'] ) ) $instance['ids'] = null;
-			$fields .= "\t<p><label for='widget-{$widget->id_base}-{$widget->number}-ids'>".apply_filters( 'widget_css_classes_id', esc_html__( 'CSS ID', 'widget-css-classes' ) ).":</label>
-			<input type='text' name='widget-{$widget->id_base}[{$widget->number}][ids]' id='widget-{$widget->id_base}-{$widget->number}-ids' value='{$instance['ids']}' class='widefat' /></p>\n";
-		}
-
-		$fields .= "<p>\n";
-
-		// show text field
-		if ( WCSSC_Loader::$settings['type'] == 1 ) {
-			$fields .= "\t<label for='widget-{$widget->id_base}-{$widget->number}-classes'>".apply_filters( 'widget_css_classes_class', esc_html__( 'CSS Class', 'widget-css-classes' ) ).":</label>
-			<input type='text' name='widget-{$widget->id_base}[{$widget->number}][classes]' id='widget-{$widget->id_base}-{$widget->number}-classes' value='{$instance['classes']}' class='widefat' />\n";
-		}
-
-		// show dropdown
-		if ( WCSSC_Loader::$settings['type'] == 2 ) {
-			$preset_values = explode( ';', WCSSC_Loader::$settings['dropdown'] );
-			$fields .= "\t<label for='widget-{$widget->id_base}-{$widget->number}-classes'>".apply_filters( 'widget_css_classes_class', esc_html__( 'CSS Class', 'widget-css-classes' ) ).":</label>\n";
-			$fields .= "\t<select name='widget-{$widget->id_base}[{$widget->number}][classes]' id='widget-{$widget->id_base}-{$widget->number}-classes' class='widefat'>\n";
-			$fields .= "\t<option value=''>".esc_attr__( 'Select', 'widget-css-classes' )."</option>\n";
-			foreach ( $preset_values as $preset ) {
-				if ( $preset != '' ) {
-					$fields .= "\t<option value='".$preset."' ".selected( $instance['classes'], $preset, 0 ).">".$preset."</option>\n";
-				}
+		
+		if ( WCSSC_Loader::$settings['show_id'] == 1 || WCSSC_Loader::$settings['type'] > 0 ) {
+			$fields .= "<div class='wcssc' style='border: 1px solid #ddd; padding: 5px; background: #fafafa; margin: 1em 0; line-height: 1.5;'>\n";
+	
+			// show id field
+			if ( WCSSC_Loader::$settings['show_id'] == 1 ) {
+				if ( !isset( $instance['ids'] ) ) $instance['ids'] = null;
+				$fields .= "\t<p style='margin-top: 0;'><label for='widget-{$widget->id_base}-{$widget->number}-ids'>".apply_filters( 'widget_css_classes_id', esc_html__( 'CSS ID', 'widget-css-classes' ) ).":</label>
+				<input type='text' name='widget-{$widget->id_base}[{$widget->number}][ids]' id='widget-{$widget->id_base}-{$widget->number}-ids' value='{$instance['ids']}' class='widefat' /></p>\n";
 			}
-			$fields .= "</select>\n";
+	
+			// show text field
+			if ( WCSSC_Loader::$settings['type'] == 1 ) {
+				$fields .= "\t<label for='widget-{$widget->id_base}-{$widget->number}-classes'>".apply_filters( 'widget_css_classes_class', esc_html__( 'CSS Classes', 'widget-css-classes' ) ).":</label>
+				<input type='text' name='widget-{$widget->id_base}[{$widget->number}][classes]' id='widget-{$widget->id_base}-{$widget->number}-classes' value='{$instance['classes']}' class='widefat' />\n";
+			}
+	
+			// show predefined
+			if ( WCSSC_Loader::$settings['type'] == 2 || WCSSC_Loader::$settings['type'] == 3 ) {
+				$preset_values = explode( ';', WCSSC_Loader::$settings['defined_classes'] );
+				$fields .= "\t<label for='widget-{$widget->id_base}-{$widget->number}-classes'>".apply_filters( 'widget_css_classes_class', esc_html__( 'CSS Classes', 'widget-css-classes' ) ).":</label>\n";
+				if ( WCSSC_Loader::$settings['type'] == 3 ) {
+					$fields .= "\t<input type='text' name='widget-{$widget->id_base}[{$widget->number}][classes]' id='widget-{$widget->id_base}-{$widget->number}-classes' value='{$instance['classes']}' class='widefat' style='margin-bottom: .5em;' />\n";
+				}
+				$fields .= "\t<ul id='widget-{$widget->id_base}-{$widget->number}-classes-defined' class='' style='background: #fff; padding: 5px; max-height: 70px; overflow: hidden; overflow-y: auto; margin: 0; border: 1px solid #ddd;'>\n";
+				foreach ( $preset_values as $preset ) {
+					if ( $preset != '' ) {
+						$preset_checked = '';
+						if ( in_array( $preset, $instance['classes-defined'] ) ) {
+							$preset_checked = 'checked="checked"';
+						}
+						$fields .= "\t<li><input name='widget-{$widget->id_base}[{$widget->number}][classes-defined][]' type='checkbox' value='".$preset."' ".$preset_checked."> ".$preset."</li>\n";
+					}
+				}
+				$fields .= "\t</ul>\n";
+			}
+	
+			$fields .= "</div>\n";
 		}
-
-		$fields .= "</p>\n";
 
 		do_action( 'widget_css_classes_form', $fields, $instance );
 
@@ -74,6 +84,7 @@ class WCSSC {
 	 */
 	public static function update_widget( $instance, $new_instance ) {
 		$instance['classes'] = $new_instance['classes'];
+		$instance['classes-defined'] = $new_instance['classes-defined'];
 		if (WCSSC_Loader::$settings['show_id'] == 1) {
 			$instance['ids']     = $new_instance['ids'];
 		}
@@ -135,11 +146,23 @@ class WCSSC {
 		}
 
 		// add classes
-		if ( $widget_css_classes['type'] != 3 ) {
+		if ( $widget_css_classes['type'] == 1 || $widget_css_classes['type'] == 3 ) {
 			if ( isset( $widget_opt[$widget_num]['classes'] ) && !empty( $widget_opt[$widget_num]['classes'] ) )
 				$params[0]['before_widget'] = preg_replace( '/class="/', "class=\"{$widget_opt[$widget_num]['classes']} ", $params[0]['before_widget'], 1 );
 		}
-
+		
+		$presets = explode( ';', $widget_css_classes['defined_classes'] );
+		if ( $widget_css_classes['type'] == 2 || $widget_css_classes['type'] == 3 ) {
+			if ( isset( $widget_opt[$widget_num]['classes-defined'] ) && !empty( $widget_opt[$widget_num]['classes-defined'] ) && is_array( $widget_opt[$widget_num]['classes-defined'] ) ) {
+				foreach ( $widget_opt[$widget_num]['classes-defined'] as $key => $value ) {
+					if ( in_array( $value, $presets ) ) {
+						$value = esc_attr( $value );
+						$params[0]['before_widget'] = preg_replace( '/class="/', "class=\"{$value} ", $params[0]['before_widget'], 1 );
+					}
+				}
+			}
+		}
+		
 		// add id
 		if ( $widget_css_classes['show_id'] == 1 ) {
 			if ( isset( $widget_opt[$widget_num]['ids'] ) && !empty( $widget_opt[$widget_num]['ids'] ) )

--- a/includes/widget-css-classes.class.php
+++ b/includes/widget-css-classes.class.php
@@ -27,6 +27,7 @@ class WCSSC {
 		if ( !isset( $instance['classes'] ) ) $instance['classes'] = null;
 		if ( !isset( $instance['classes-defined'] ) ) $instance['classes-defined'] = array();
 		
+				
 		$fields = '';
 		
 		if ( WCSSC_Loader::$settings['show_id'] == 1 || WCSSC_Loader::$settings['type'] > 0 ) {
@@ -47,7 +48,22 @@ class WCSSC {
 	
 			// show predefined
 			if ( WCSSC_Loader::$settings['type'] == 2 || WCSSC_Loader::$settings['type'] == 3 ) {
+				
+				// Merge input classes with predefined classes
 				$preset_values = explode( ';', WCSSC_Loader::$settings['defined_classes'] );
+				if ( isset( $instance['classes'] ) ) {
+					$text_classes = explode( ' ', $instance['classes'] );
+					foreach ( $text_classes as $key => $value ) {
+						if ( in_array( $value, $preset_values ) ) {
+							if ( ! in_array( $value, $instance['classes-defined'] ) ) {
+								$instance['classes-defined'][] = $value;
+							}
+							unset( $text_classes[ $key ] );					
+						}
+					}
+					$instance['classes'] = implode( ' ', $text_classes );
+				}
+				
 				$fields .= "\t<label for='widget-{$widget->id_base}-{$widget->number}-classes'>".apply_filters( 'widget_css_classes_class', esc_html__( 'CSS Classes', 'widget-css-classes' ) ).":</label>\n";
 				if ( WCSSC_Loader::$settings['type'] == 3 ) {
 					$fields .= "\t<input type='text' name='widget-{$widget->id_base}[{$widget->number}][classes]' id='widget-{$widget->id_base}-{$widget->number}-classes' value='{$instance['classes']}' class='widefat' style='margin-bottom: .5em;' />\n";
@@ -88,6 +104,24 @@ class WCSSC {
 		if (WCSSC_Loader::$settings['show_id'] == 1) {
 			$instance['ids']     = $new_instance['ids'];
 		}
+		
+		if ( WCSSC_Loader::$settings['type'] == 2 || WCSSC_Loader::$settings['type'] == 3 ) {
+			// Merge input classes with predefined classes
+			$preset_values = explode( ';', WCSSC_Loader::$settings['defined_classes'] );
+			if ( isset( $instance['classes'] ) ) {
+				$text_classes = explode( ' ', $instance['classes'] );
+				foreach ( $text_classes as $key => $value ) {
+					if ( in_array( $value, $preset_values ) ) {
+						if ( ! in_array( $value, $instance['classes-defined'] ) ) {
+							$instance['classes-defined'][] = $value;
+						}
+						unset( $text_classes[ $key ] );					
+					}
+				}
+				$instance['classes'] = implode( ' ', $text_classes );
+			}
+		}
+		
 		do_action( 'widget_css_classes_update', $instance, $new_instance );
 		return $instance;
 	}
@@ -151,7 +185,6 @@ class WCSSC {
 				$params[0]['before_widget'] = preg_replace( '/class="/', "class=\"{$widget_opt[$widget_num]['classes']} ", $params[0]['before_widget'], 1 );
 		}
 		
-		// add selected predefined classes
 		$presets = explode( ';', $widget_css_classes['defined_classes'] );
 		if ( $widget_css_classes['type'] == 2 || $widget_css_classes['type'] == 3 ) {
 			if ( isset( $widget_opt[$widget_num]['classes-defined'] ) && !empty( $widget_opt[$widget_num]['classes-defined'] ) && is_array( $widget_opt[$widget_num]['classes-defined'] ) ) {

--- a/includes/widget-css-classes.class.php
+++ b/includes/widget-css-classes.class.php
@@ -40,17 +40,7 @@ class WCSSC {
 			}
 	
 			// show text field only
-			if ( WCSSC_Loader::$settings['type'] == 1 ) {
-				
-				// Merge predefined classes with input classes
-				$text_classes = explode( ' ', $instance['classes'] );
-				foreach ( $instance['classes-defined'] as $key => $value ) {
-					if ( ! in_array( $value, $text_classes ) ) {
-						$text_classes[] = $value;
-					}
-				}
-				$instance['classes'] = implode( ' ', $text_classes );
-				
+			if ( WCSSC_Loader::$settings['type'] == 1 ) {				
 				$fields .= "\t<label for='widget-{$widget->id_base}-{$widget->number}-classes'>".apply_filters( 'widget_css_classes_class', esc_html__( 'CSS Classes', 'widget-css-classes' ) ).":</label>
 				<input type='text' name='widget-{$widget->id_base}[{$widget->number}][classes]' id='widget-{$widget->id_base}-{$widget->number}-classes' value='{$instance['classes']}' class='widefat' />\n";
 			}
@@ -59,15 +49,15 @@ class WCSSC {
 			if ( WCSSC_Loader::$settings['type'] == 2 || WCSSC_Loader::$settings['type'] == 3 ) {
 				
 				// Merge input classes with predefined classes
-				$preset_values = explode( ';', WCSSC_Loader::$settings['defined_classes'] );
+				$predefined_classes = explode( ';', WCSSC_Loader::$settings['defined_classes'] );
 				if ( isset( $instance['classes'] ) ) {
 					$text_classes = explode( ' ', $instance['classes'] );
 					foreach ( $text_classes as $key => $value ) {
-						if ( in_array( $value, $preset_values ) ) {
+						if ( in_array( $value, $predefined_classes ) ) {
 							if ( ! in_array( $value, $instance['classes-defined'] ) ) {
 								$instance['classes-defined'][] = $value;
 							}
-							unset( $text_classes[ $key ] );					
+							unset( $text_classes[ $key ] );
 						}
 					}
 					$instance['classes'] = implode( ' ', $text_classes );
@@ -75,11 +65,11 @@ class WCSSC {
 				
 				$fields .= "\t<label for='widget-{$widget->id_base}-{$widget->number}-classes'>".apply_filters( 'widget_css_classes_class', esc_html__( 'CSS Classes', 'widget-css-classes' ) ).":</label>\n";
 				if ( WCSSC_Loader::$settings['type'] == 3 ) {
-					// also show text field
+					// show text field
 					$fields .= "\t<input type='text' name='widget-{$widget->id_base}[{$widget->number}][classes]' id='widget-{$widget->id_base}-{$widget->number}-classes' value='{$instance['classes']}' class='widefat' style='margin-bottom: .5em;' />\n";
 				}
 				$fields .= "\t<ul id='widget-{$widget->id_base}-{$widget->number}-classes-defined' class='' style='background: #fff; padding: 5px; max-height: 70px; overflow: hidden; overflow-y: auto; margin: 0; border: 1px solid #ddd;'>\n";
-				foreach ( $preset_values as $preset ) {
+				foreach ( $predefined_classes as $preset ) {
 					if ( $preset != '' ) {
 						$preset_checked = '';
 						if ( in_array( $preset, $instance['classes-defined'] ) ) {
@@ -114,8 +104,7 @@ class WCSSC {
 		if (WCSSC_Loader::$settings['show_id'] == 1) {
 			$instance['ids']     = $new_instance['ids'];
 		}
-		
-		if ( WCSSC_Loader::$settings['type'] == 1 && is_array( $instance['classes-defined'] ) ) {
+		if ( is_array( $instance['classes-defined'] ) ) {
 			// Merge predefined classes with input classes
 			$text_classes = explode( ' ', $instance['classes'] );
 			foreach ( $instance['classes-defined'] as $key => $value ) {
@@ -125,22 +114,8 @@ class WCSSC {
 			}
 			$instance['classes'] = implode( ' ', $text_classes );
 		}
-		if ( WCSSC_Loader::$settings['type'] == 2 || WCSSC_Loader::$settings['type'] == 3 ) {
-			// Merge input classes with predefined classes
-			$preset_values = explode( ';', WCSSC_Loader::$settings['defined_classes'] );
-			if ( isset( $instance['classes'] ) && is_array( $instance['classes-defined'] ) ) {
-				$text_classes = explode( ' ', $instance['classes'] );
-				foreach ( $text_classes as $key => $value ) {
-					if ( in_array( $value, $preset_values ) ) {
-						if ( ! in_array( $value, $instance['classes-defined'] ) ) {
-							$instance['classes-defined'][] = $value;
-						}
-						unset( $text_classes[ $key ] );					
-					}
-				}
-				$instance['classes'] = implode( ' ', $text_classes );
-			}
-		}
+		// Do not store predefined array in widget, no need
+		unset( $instance['classes-defined'] );
 		
 		do_action( 'widget_css_classes_update', $instance, $new_instance );
 		return $instance;
@@ -165,7 +140,7 @@ class WCSSC {
 		$widget_css_classes     = ( get_option( 'WCSSC_options' ) ? get_option( 'WCSSC_options' ) : array() );
 		$widget_opt             = null;
 
-		// if Widget Logic plugin is enabled, use it's callback
+		// If Widget Logic plugin is enabled, use it's callback
 		if ( in_array( 'widget-logic/widget_logic.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
 			$widget_logic_options = get_option( 'widget_logic' );
 			if ( isset( $widget_logic_options['widget_logic-options-filter'] ) && 'checked' == $widget_logic_options['widget_logic-options-filter'] ) {
@@ -174,7 +149,7 @@ class WCSSC {
 				$widget_opt = get_option( $widget_obj['callback'][0]->option_name );
 			}
 
-		// if Widget Context plugin is enabled, use it's callback
+		// If Widget Context plugin is enabled, use it's callback
 		} elseif ( in_array( 'widget-context/widget-context.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
 			$callback = isset($widget_obj['callback_original_wc']) ? $widget_obj['callback_original_wc'] : null;
 			$callback = !$callback && isset($widget_obj['callback']) ? $widget_obj['callback'] : null;
@@ -199,42 +174,19 @@ class WCSSC {
 			}
 		}
 
-		$presets = explode( ';', $widget_css_classes['defined_classes'] );
 		
-		// add classes
-		if ( $widget_css_classes['type'] == 1 || $widget_css_classes['type'] == 3 ) {
-			if ( isset( $widget_opt[$widget_num]['classes'] ) && !empty( $widget_opt[$widget_num]['classes'] ) ) {
+		// Add classes
+		if ( isset( $widget_opt[$widget_num]['classes'] ) && !empty( $widget_opt[$widget_num]['classes'] ) ) {
+			
+			if ( $widget_css_classes['type'] == 1 || $widget_css_classes['type'] == 3 ) {
+				// Add all classes
 				$params[0]['before_widget'] = preg_replace( '/class="/', "class=\"{$widget_opt[$widget_num]['classes']} ", $params[0]['before_widget'], 1 );
-			}
-			// If there are predefined classes selected in the widget before the setting was changed, check if they exist. If so, add them to the displayed classes
-			if ( 	$widget_css_classes['type'] == 1 
-				 && isset( $widget_opt[$widget_num]['classes-defined'] ) 
-				 && !empty( $widget_opt[$widget_num]['classes-defined'] ) 
-				 && is_array( $widget_opt[$widget_num]['classes-defined'] ) 
-			) {
-				foreach ( $widget_opt[$widget_num]['classes-defined'] as $key => $value ) {
-					if ( in_array( $value, $presets ) ) {
-						$value = esc_attr( $value );
-						$params[0]['before_widget'] = preg_replace( '/class="/', "class=\"{$value} ", $params[0]['before_widget'], 1 );
-					}
-				}
-			}
-		}
-		
-		// add selected predefined classes
-		if ( $widget_css_classes['type'] == 2 || $widget_css_classes['type'] == 3 ) {
-			if ( isset( $widget_opt[$widget_num]['classes-defined'] ) && !empty( $widget_opt[$widget_num]['classes-defined'] ) && is_array( $widget_opt[$widget_num]['classes-defined'] ) ) {
-				foreach ( $widget_opt[$widget_num]['classes-defined'] as $key => $value ) {
-					if ( in_array( $value, $presets ) ) {
-						$value = esc_attr( $value );
-						$params[0]['before_widget'] = preg_replace( '/class="/', "class=\"{$value} ", $params[0]['before_widget'], 1 );
-					}
-				}
-			} else if ( $widget_css_classes['type'] == 2 && isset( $widget_opt[$widget_num]['classes'] ) && !empty( $widget_opt[$widget_num]['classes'] ) ) {
-				// Add predefined classes if they are set as normal classes. Also takes case of compatibility for versions lower than 1.3
+			} else if ( $widget_css_classes['type'] == 2 ) {
+				// Only add predefined classes
+				$predefined_classes = explode( ';', $widget_css_classes['defined_classes'] );
 				$classes = explode( ' ', $widget_opt[$widget_num]['classes'] );
 				foreach ( $classes as $key => $value ) {
-					if ( in_array( $value, $presets ) ) {
+					if ( in_array( $value, $predefined_classes ) ) {
 						$value = esc_attr( $value );
 						$params[0]['before_widget'] = preg_replace( '/class="/', "class=\"{$value} ", $params[0]['before_widget'], 1 );
 					}
@@ -242,13 +194,13 @@ class WCSSC {
 			}
 		}
 		
-		// add id
+		// Add id
 		if ( $widget_css_classes['show_id'] == 1 ) {
 			if ( isset( $widget_opt[$widget_num]['ids'] ) && !empty( $widget_opt[$widget_num]['ids'] ) )
 				$params[0]['before_widget'] = preg_replace( '/id="[^"]*/', "id=\"{$widget_opt[$widget_num]['ids']}", $params[0]['before_widget'], 1 );
 		}
 
-		// add first, last, even, and odd classes
+		// Add first, last, even, and odd classes
 		if ( $widget_css_classes['show_number'] == 1 || $widget_css_classes['show_location'] == 1 || $widget_css_classes['show_evenodd'] == 1 ) {
 			if ( !$widget_number ) {
 				$widget_number = array();

--- a/includes/widget-css-classes.class.php
+++ b/includes/widget-css-classes.class.php
@@ -39,7 +39,7 @@ class WCSSC {
 				<input type='text' name='widget-{$widget->id_base}[{$widget->number}][ids]' id='widget-{$widget->id_base}-{$widget->number}-ids' value='{$instance['ids']}' class='widefat' /></p>\n";
 			}
 	
-			// show text field
+			// show text field only
 			if ( WCSSC_Loader::$settings['type'] == 1 ) {
 				
 				// Merge predefined classes with input classes
@@ -75,6 +75,7 @@ class WCSSC {
 				
 				$fields .= "\t<label for='widget-{$widget->id_base}-{$widget->number}-classes'>".apply_filters( 'widget_css_classes_class', esc_html__( 'CSS Classes', 'widget-css-classes' ) ).":</label>\n";
 				if ( WCSSC_Loader::$settings['type'] == 3 ) {
+					// also show text field
 					$fields .= "\t<input type='text' name='widget-{$widget->id_base}[{$widget->number}][classes]' id='widget-{$widget->id_base}-{$widget->number}-classes' value='{$instance['classes']}' class='widefat' style='margin-bottom: .5em;' />\n";
 				}
 				$fields .= "\t<ul id='widget-{$widget->id_base}-{$widget->number}-classes-defined' class='' style='background: #fff; padding: 5px; max-height: 70px; overflow: hidden; overflow-y: auto; margin: 0; border: 1px solid #ddd;'>\n";

--- a/includes/widget-css-classes.class.php
+++ b/includes/widget-css-classes.class.php
@@ -115,7 +115,7 @@ class WCSSC {
 			$instance['ids']     = $new_instance['ids'];
 		}
 		
-		if ( WCSSC_Loader::$settings['type'] == 1 ) {
+		if ( WCSSC_Loader::$settings['type'] == 1 && is_array( $instance['classes-defined'] ) ) {
 			// Merge predefined classes with input classes
 			$text_classes = explode( ' ', $instance['classes'] );
 			foreach ( $instance['classes-defined'] as $key => $value ) {
@@ -128,7 +128,7 @@ class WCSSC {
 		if ( WCSSC_Loader::$settings['type'] == 2 || WCSSC_Loader::$settings['type'] == 3 ) {
 			// Merge input classes with predefined classes
 			$preset_values = explode( ';', WCSSC_Loader::$settings['defined_classes'] );
-			if ( isset( $instance['classes'] ) ) {
+			if ( isset( $instance['classes'] ) && is_array( $instance['classes-defined'] ) ) {
 				$text_classes = explode( ' ', $instance['classes'] );
 				foreach ( $text_classes as $key => $value ) {
 					if ( in_array( $value, $preset_values ) ) {

--- a/includes/widget-css-classes.class.php
+++ b/includes/widget-css-classes.class.php
@@ -151,6 +151,7 @@ class WCSSC {
 				$params[0]['before_widget'] = preg_replace( '/class="/', "class=\"{$widget_opt[$widget_num]['classes']} ", $params[0]['before_widget'], 1 );
 		}
 		
+		// add selected predefined classes
 		$presets = explode( ';', $widget_css_classes['defined_classes'] );
 		if ( $widget_css_classes['type'] == 2 || $widget_css_classes['type'] == 3 ) {
 			if ( isset( $widget_opt[$widget_num]['classes-defined'] ) && !empty( $widget_opt[$widget_num]['classes-defined'] ) && is_array( $widget_opt[$widget_num]['classes-defined'] ) ) {

--- a/languages/widget-css-classes-nl_NL.po
+++ b/languages/widget-css-classes-nl_NL.po
@@ -1,0 +1,166 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Widget CSS Classes\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-22 23:40+0100\n"
+"PO-Revision-Date: 2015-12-22 23:44+0100\n"
+"Last-Translator: C.M. Kendrick <cindy@cleverness.org>\n"
+"Language-Team:  <cindy@cleverness.org>\n"
+"Language: nl_NL\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Poedit-KeywordsList: _;_e;esc_attr__;esc_attr_e;esc_html__;esc_html_e\n"
+"X-Poedit-Basepath: ./\n"
+"X-Generator: Poedit 1.6.10\n"
+"X-Poedit-SearchPath-0: ..\n"
+
+#: ../includes/widget-css-classes-library.class.php:31
+msgid "Settings"
+msgstr "Instellingen"
+
+#: ../includes/widget-css-classes-library.class.php:45
+msgid "Version"
+msgstr "Versie"
+
+#: ../includes/widget-css-classes-library.class.php:46
+msgid "Donate"
+msgstr "Doneren"
+
+#: ../includes/widget-css-classes-loader.class.php:40
+#: ../widget-css-classes.php:55
+msgid ""
+"Widget CSS Classes requires WordPress 3.3 or newer. <a href=\"http://codex."
+"wordpress.org/Upgrading_WordPress\">Please update.</a>"
+msgstr ""
+"Voor Widget CSS Classes is WordPress versie 3.3 of hoger vereist. <a href="
+"\"http://codex.wordpress.org/Upgrading_WordPress\">Updaten a.u.b..</a>"
+
+#: ../includes/widget-css-classes-settings.class.php:39
+#: ../includes/widget-css-classes-settings.class.php:42
+msgid "Widget CSS Classes Settings"
+msgstr "Widget CSS Classes Instellingen"
+
+#: ../includes/widget-css-classes-settings.class.php:43
+msgid "Add Widget Number Classes"
+msgstr "Voeg numerieke Classes toe"
+
+#: ../includes/widget-css-classes-settings.class.php:44
+msgid "Add First/Last Classes"
+msgstr "Voeg First/Last Classes toe"
+
+#: ../includes/widget-css-classes-settings.class.php:45
+msgid "Add Even/Odd Classes"
+msgstr "Voeg Even/Odd Classes toe"
+
+#: ../includes/widget-css-classes-settings.class.php:46
+msgid "Show Additional Field for ID"
+msgstr "Toon extra veld voor ID"
+
+#: ../includes/widget-css-classes-settings.class.php:47
+msgid "Class Field Type"
+msgstr "Soort Class veld"
+
+#: ../includes/widget-css-classes-settings.class.php:48
+msgid "Predefined Classes"
+msgstr "Vooraf bepaalde Classes"
+
+#: ../includes/widget-css-classes-settings.class.php:53
+#: ../includes/widget-css-classes-settings.class.php:60
+#: ../includes/widget-css-classes-settings.class.php:67
+#: ../includes/widget-css-classes-settings.class.php:74
+msgid "Yes"
+msgstr "Ja"
+
+#: ../includes/widget-css-classes-settings.class.php:54
+#: ../includes/widget-css-classes-settings.class.php:61
+#: ../includes/widget-css-classes-settings.class.php:68
+#: ../includes/widget-css-classes-settings.class.php:75
+msgid "No"
+msgstr "Nee"
+
+#: ../includes/widget-css-classes-settings.class.php:81
+msgid "Text"
+msgstr "Tekst"
+
+#: ../includes/widget-css-classes-settings.class.php:82
+msgid "Predefined"
+msgstr "Vooraf bepaald"
+
+#: ../includes/widget-css-classes-settings.class.php:83
+msgid "Both"
+msgstr "Beide"
+
+#: ../includes/widget-css-classes-settings.class.php:84
+msgid "Hide"
+msgstr "Verbergen"
+
+#: ../includes/widget-css-classes-settings.class.php:116
+msgid "Import/Export"
+msgstr "Importeren/Exporteren"
+
+#: ../includes/widget-css-classes-settings.class.php:121
+msgid "Settings Imported"
+msgstr "Instellingen geïmporteerd"
+
+#: ../includes/widget-css-classes-settings.class.php:124
+msgid "Invalid Settings File"
+msgstr "Ongeldig instellingen bestand"
+
+#: ../includes/widget-css-classes-settings.class.php:127
+msgid "No Settings File Selected"
+msgstr "Geen instellingen bestand geselecteerd"
+
+#: ../includes/widget-css-classes-settings.class.php:198
+msgid "Widget CSS Classes"
+msgstr "Widget CSS Classes"
+
+#: ../includes/widget-css-classes-settings.class.php:243
+msgid "Import/Export Settings"
+msgstr "Instellingen importeren/exporteren"
+
+#: ../includes/widget-css-classes-settings.class.php:245
+msgid "Export Settings"
+msgstr "Instellingen exporteren"
+
+#: ../includes/widget-css-classes-settings.class.php:249
+msgid "Import Settings"
+msgstr "Instellingen importeren"
+
+#: ../includes/widget-css-classes.class.php:38
+msgid "CSS ID"
+msgstr "CSS ID"
+
+#: ../includes/widget-css-classes.class.php:44
+#: ../includes/widget-css-classes.class.php:51
+msgid "CSS Classes"
+msgstr "CSS Classes"
+
+#: ../includes/widget-css-classes.class.php:191
+msgid "widget-"
+msgstr "widget-"
+
+#: ../includes/widget-css-classes.class.php:195
+msgid "widget-first"
+msgstr "widget-first"
+
+#: ../includes/widget-css-classes.class.php:196
+msgid "widget-last"
+msgstr "widget-last"
+
+#: ../includes/widget-css-classes.class.php:206
+msgid "widget-even"
+msgstr "widget-even"
+
+#: ../includes/widget-css-classes.class.php:207
+msgid "widget-odd"
+msgstr "widget-odd"
+
+#~ msgid "Define Classes for Dropdown"
+#~ msgstr "Classes definiëren voor dropdown"
+
+#~ msgid "Dropdown"
+#~ msgstr "Dropdown"
+
+#~ msgid "Select"
+#~ msgstr "Selecteren"

--- a/languages/widget-css-classes.pot
+++ b/languages/widget-css-classes.pot
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widget CSS Classes\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-12-02 15:50-0500\n"
-"PO-Revision-Date: 2012-12-02 15:50-0500\n"
+"POT-Creation-Date: 2015-12-22 23:40+0100\n"
+"PO-Revision-Date: 2015-12-22 23:40+0100\n"
 "Last-Translator: C.M. Kendrick <cindy@cleverness.org>\n"
 "Language-Team:  <cindy@cleverness.org>\n"
 "MIME-Version: 1.0\n"
@@ -11,15 +11,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-KeywordsList: _;_e;esc_attr__;esc_attr_e;esc_html__;esc_html_e\n"
 "X-Poedit-Basepath: ./\n"
-"X-Generator: Poedit 1.5.4\n"
+"X-Generator: Poedit 1.6.10\n"
 "X-Poedit-SearchPath-0: ..\n"
-
-#: ../widget-css-classes.php:54
-#: ../includes/widget-css-classes-loader.class.php:40
-msgid ""
-"Widget CSS Classes requires WordPress 3.3 or newer. <a href=\"http://codex."
-"wordpress.org/Upgrading_WordPress\">Please update.</a>"
-msgstr ""
 
 #: ../includes/widget-css-classes-library.class.php:31
 msgid "Settings"
@@ -31,6 +24,13 @@ msgstr ""
 
 #: ../includes/widget-css-classes-library.class.php:46
 msgid "Donate"
+msgstr ""
+
+#: ../includes/widget-css-classes-loader.class.php:40
+#: ../widget-css-classes.php:55
+msgid ""
+"Widget CSS Classes requires WordPress 3.3 or newer. <a href=\"http://codex."
+"wordpress.org/Upgrading_WordPress\">Please update.</a>"
 msgstr ""
 
 #: ../includes/widget-css-classes-settings.class.php:39
@@ -59,7 +59,7 @@ msgid "Class Field Type"
 msgstr ""
 
 #: ../includes/widget-css-classes-settings.class.php:48
-msgid "Define Classes for Dropdown"
+msgid "Predefined Classes"
 msgstr ""
 
 #: ../includes/widget-css-classes-settings.class.php:53
@@ -81,30 +81,34 @@ msgid "Text"
 msgstr ""
 
 #: ../includes/widget-css-classes-settings.class.php:82
-msgid "Dropdown"
+msgid "Predefined"
 msgstr ""
 
 #: ../includes/widget-css-classes-settings.class.php:83
+msgid "Both"
+msgstr ""
+
+#: ../includes/widget-css-classes-settings.class.php:84
 msgid "Hide"
 msgstr ""
 
-#: ../includes/widget-css-classes-settings.class.php:115
+#: ../includes/widget-css-classes-settings.class.php:116
 msgid "Import/Export"
 msgstr ""
 
-#: ../includes/widget-css-classes-settings.class.php:120
+#: ../includes/widget-css-classes-settings.class.php:121
 msgid "Settings Imported"
 msgstr ""
 
-#: ../includes/widget-css-classes-settings.class.php:123
+#: ../includes/widget-css-classes-settings.class.php:124
 msgid "Invalid Settings File"
 msgstr ""
 
-#: ../includes/widget-css-classes-settings.class.php:126
+#: ../includes/widget-css-classes-settings.class.php:127
 msgid "No Settings File Selected"
 msgstr ""
 
-#: ../includes/widget-css-classes-settings.class.php:197
+#: ../includes/widget-css-classes-settings.class.php:198
 msgid "Widget CSS Classes"
 msgstr ""
 
@@ -120,35 +124,31 @@ msgstr ""
 msgid "Import Settings"
 msgstr ""
 
-#: ../includes/widget-css-classes.class.php:34
+#: ../includes/widget-css-classes.class.php:38
 msgid "CSS ID"
 msgstr ""
 
-#: ../includes/widget-css-classes.class.php:40
-#: ../includes/widget-css-classes.class.php:47
-msgid "CSS Class"
+#: ../includes/widget-css-classes.class.php:44
+#: ../includes/widget-css-classes.class.php:51
+msgid "CSS Classes"
 msgstr ""
 
-#: ../includes/widget-css-classes.class.php:49
-msgid "Select"
-msgstr ""
-
-#: ../includes/widget-css-classes.class.php:147
+#: ../includes/widget-css-classes.class.php:191
 msgid "widget-"
 msgstr ""
 
-#: ../includes/widget-css-classes.class.php:151
+#: ../includes/widget-css-classes.class.php:195
 msgid "widget-first"
 msgstr ""
 
-#: ../includes/widget-css-classes.class.php:152
+#: ../includes/widget-css-classes.class.php:196
 msgid "widget-last"
 msgstr ""
 
-#: ../includes/widget-css-classes.class.php:162
+#: ../includes/widget-css-classes.class.php:206
 msgid "widget-even"
 msgstr ""
 
-#: ../includes/widget-css-classes.class.php:163
+#: ../includes/widget-css-classes.class.php:207
 msgid "widget-odd"
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,7 @@ License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Requires at least: 3.3
 Tested up to: 4.4
-Stable tag: 1.2.9
+Stable tag: 1.3.0
 
 Add custom classes and ids plus first, last, even, odd, and numbered classes to your widgets.
 

--- a/readme.txt
+++ b/readme.txt
@@ -95,7 +95,7 @@ Visit [the plugin website](http://cleverness.org/plugins/widget-css-classes/) an
 == Changelog ==
 
 = 1.3.0 =
-* Feature: Change dropdown to checkboxes for multiple select
+* Feature: Change dropdown to checkboxes for multiple class selection
 * Featute: Option to use both defined and text input classes
 * Feature: Migrate classes when predefined classes are available
 * Improvement: Do not show previously defined classes that are removed in the settings page when a widget is not updated yet

--- a/readme.txt
+++ b/readme.txt
@@ -95,11 +95,13 @@ Visit [the plugin website](http://cleverness.org/plugins/widget-css-classes/) an
 == Changelog ==
 
 = 1.3.0 =
-* Change dropdown to checkboxes for multiple select
-* Option to use both defined and text input classes
+* Feature: Change dropdown to checkboxes for multiple select
+* Featute: Option to use both defined and text input classes
+* Feature: Migrate classes when predefined classes are available
 * Improvement: Do not show previously defined classes that are removed in the settings page when a widget is not updated yet
 * Fix: Only show stored classes if the field-type in the setting page is correct
-* Added Dutch translation by [Jory Hogeveen at Keraweb](https://www.keraweb.nl/)
+* Fix: When predefined is selected, show previous text input classes if they are defined
+* i18n: Added Dutch translation by [Jory Hogeveen at Keraweb](https://www.keraweb.nl/)
 
 = 1.2.9 =
 * Changed h2 to h1 on settings page

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,7 @@ Visit [the plugin website](http://cleverness.org/plugins/widget-css-classes/) an
 * Option to use both defined and text input classes
 * Improvement: Do not show previously defined classes that are removed in the settings page when a widget is not updated yet
 * Fix: Only show stored classes if the field-type in the setting page is correct
+* Added Dutch translation by [Jory Hogeveen at Keraweb](https://www.keraweb.nl/)
 
 = 1.2.9 =
 * Changed h2 to h1 on settings page

--- a/readme.txt
+++ b/readme.txt
@@ -94,6 +94,12 @@ Visit [the plugin website](http://cleverness.org/plugins/widget-css-classes/) an
 
 == Changelog ==
 
+= 1.3.0 =
+* Change dropdown to checkboxes for multiple select
+* Option to use both defined and text input classes
+* Do not show previously defined classes that are removed in the settings page when a widget is not updated yet
+* Only show stored classes if the field-type in the setting page is correct
+
 = 1.2.9 =
 * Changed h2 to h1 on settings page
 * Changed plus/minus icons on settings page to dashicons

--- a/readme.txt
+++ b/readme.txt
@@ -97,8 +97,8 @@ Visit [the plugin website](http://cleverness.org/plugins/widget-css-classes/) an
 = 1.3.0 =
 * Change dropdown to checkboxes for multiple select
 * Option to use both defined and text input classes
-* Do not show previously defined classes that are removed in the settings page when a widget is not updated yet
-* Only show stored classes if the field-type in the setting page is correct
+* Improvement: Do not show previously defined classes that are removed in the settings page when a widget is not updated yet
+* Fix: Only show stored classes if the field-type in the setting page is correct
 
 = 1.2.9 =
 * Changed h2 to h1 on settings page

--- a/widget-css-classes.php
+++ b/widget-css-classes.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Widget CSS Classes
-Version: 1.2.9
+Version: 1.3.0
 Description: Add custom, first, last, even, odd, and numbered classes to your widgets.
 Author: C.M. Kendrick
 Author URI: http://cleverness.org
@@ -57,7 +57,7 @@ function widget_css_classes_activation() {
 		exit( $exit_msg );
 	}
 
-	if ( !defined( 'WCSSC_DB_VERSION' ) ) define( 'WCSSC_DB_VERSION', '1.2' );
+	if ( !defined( 'WCSSC_DB_VERSION' ) ) define( 'WCSSC_DB_VERSION', '1.3' );
 	if ( !defined( 'WCSSC_FILE' ) ) define( 'WCSSC_FILE', __FILE__ );
 	include_once 'includes/widget-css-classes-library.class.php';
 


### PR DESCRIPTION
**CHANGELOG:**
1.3.0
* Feature: Change dropdown to checkboxes for multiple class selection
* Featute: Option to use both defined and text input classes
* Feature: Migrate classes when predefined classes are available
* Improvement: Do not show previously defined classes that are removed in the settings page when a widget is not updated yet
* Fix: Only show stored classes if the field-type in the setting page is correct
* Fix: When predefined is selected, show previous text input classes if they are defined
* i18n: Added Dutch translation
* Backend: "dropdown" setting is changed to "defined_classes"
* Backend: "hide" type is now "0" in the settings instead of "3" -> "3" is now used for the "both" type

**TODO:**

* Update other translations
* Versions of other files (main plugin file version is updated to 1.3.0 + DB version is updated to 1.3)
  * I didn't quite understand the version-system of the other files so I'll leave that to you!

**TESTS** (worked in my tests - please also check!):

* Testing migration from 1.2 DB version to 1.3
* Import/Export functions (also import from 1.2 DB version)
* All classes in widgets will keep working. Selected classes on dropdown will be migrated to the new multicheckbox option
* Merge previous dropdown classes with the new classes.
* Full migrations functionality for text-input classes and predefined classes.
  * When text-input classes are defined, check if they exist in the predefined classes, if so, add them and remove them from the text-input classes (only for type "predefined" and "both")
  * When text-input type is selected, check if there are predefined classes selected, if so, add them to the text-input field.
  * Do the above also for display to make sure classes will not be lost when a different type is selected.